### PR TITLE
When binding framebuffer on GLES, assume textures are 2D

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -416,16 +416,7 @@ impl Device {
             &TargetView::Surface(surface) => unsafe {
                 gl.FramebufferRenderbuffer(point, attachment, gl::RENDERBUFFER, surface);
             },
-            &TargetView::Texture(texture, level) => unsafe {
-                if self.info.version.is_embedded {
-                    gl.FramebufferTexture2D(point, attachment, gl::TEXTURE_2D, texture, 
-                                            level as gl::types::GLint);
-                }
-                else {
-                    gl.FramebufferTexture(point, attachment, texture,
-                                          level as gl::types::GLint);
-                }
-            },
+            &TargetView::Texture(texture, level) => state::set_framebuffer_texture(gl, point, attachment, texture, level, self.info.version.is_embedded),
             &TargetView::TextureLayer(texture, level, layer) => unsafe {
                 gl.FramebufferTextureLayer(point, attachment, texture,
                                            level as gl::types::GLint,
@@ -436,14 +427,7 @@ impl Device {
 
     fn unbind_target(&mut self, point: gl::types::GLenum, attachment: gl::types::GLenum) {
         let gl = &self.share.context;
-        unsafe { 
-            if self.info.version.is_embedded {
-                gl.FramebufferTexture2D(point, attachment, gl::TEXTURE_2D, 0, 0);
-            }
-            else {
-                gl.FramebufferTexture(point, attachment, 0, 0);
-            }
-        }
+        state::set_framebuffer_texture(gl, point, attachment, 0, 0, self.info.version.is_embedded);
     }
 
     fn reset_state(&mut self) {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -417,8 +417,14 @@ impl Device {
                 gl.FramebufferRenderbuffer(point, attachment, gl::RENDERBUFFER, surface);
             },
             &TargetView::Texture(texture, level) => unsafe {
-                gl.FramebufferTexture(point, attachment, texture,
-                                      level as gl::types::GLint);
+                if self.info.version.is_embedded {
+                    gl.FramebufferTexture2D(point, attachment, gl::TEXTURE_2D, texture, 
+                                            level as gl::types::GLint);
+                }
+                else {
+                    gl.FramebufferTexture(point, attachment, texture,
+                                          level as gl::types::GLint);
+                }
             },
             &TargetView::TextureLayer(texture, level, layer) => unsafe {
                 gl.FramebufferTextureLayer(point, attachment, texture,
@@ -430,7 +436,14 @@ impl Device {
 
     fn unbind_target(&mut self, point: gl::types::GLenum, attachment: gl::types::GLenum) {
         let gl = &self.share.context;
-        unsafe { gl.FramebufferTexture(point, attachment, 0, 0) };
+        unsafe { 
+            if self.info.version.is_embedded {
+                gl.FramebufferTexture2D(point, attachment, gl::TEXTURE_2D, 0, 0);
+            }
+            else {
+                gl.FramebufferTexture(point, attachment, 0, 0);
+            }
+        }
     }
 
     fn reset_state(&mut self) {
@@ -646,13 +659,13 @@ impl Device {
                 }
             },
             Command::CopyTextureToBuffer(ref src, dst, dst_offset, fbo) => {
-                match tex::copy_to_buffer(&self.share.context, src, dst, dst_offset, fbo) {
+                match tex::copy_to_buffer(&self.share.context, src, dst, dst_offset, fbo, self.info.version.is_embedded) {
                     Ok(_) => (),
                     Err(e) => error!("GL: {:?} failed: {:?}", cmd, e)
                 }
             },
             Command::CopyTextureToTexture(ref src, ref dst, fbo) => {
-                match tex::copy_textures(&self.share.context, src, dst, fbo) {
+                match tex::copy_textures(&self.share.context, src, dst, fbo, self.info.version.is_embedded) {
                     Ok(_) => (),
                     Err(e) => error!("GL: {:?} failed: {:?}", cmd, e)
                 }

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -16,9 +16,20 @@ use core::{MAX_COLOR_TARGETS, ColorSlot};
 use core::state as s;
 use core::state::{BlendValue, Comparison, CullFace, Equation,
                   Offset, RasterMethod, StencilOp, FrontFace};
-use core::target::{ColorValue, Rect, Stencil};
+use core::target::{ColorValue, Level, Rect, Stencil};
 use gl;
 
+pub fn set_framebuffer_texture(gl: &gl::Gl, point: gl::types::GLenum, attachment: gl::types::GLenum, texture: crate::Texture, level: Level, is_embedded: bool) {
+    unsafe {
+        if is_embedded {
+            gl.FramebufferTexture2D(point, attachment, gl::TEXTURE_2D, texture, 
+                                    level as gl::types::GLint);
+        } else {
+            gl.FramebufferTexture(point, attachment, texture,
+                                  level as gl::types::GLint);
+        }
+    }
+}
 
 pub fn bind_raster_method(gl: &gl::Gl, method: s::RasterMethod, offset: Option<s::Offset>) {
     let (gl_draw, gl_offset) = match method {

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -773,12 +773,7 @@ fn bind_read_fbo(gl: &gl::Gl, texture: NewTexture, level: t::Level, fbo: FrameBu
                 gl.FramebufferRenderbuffer(target, gl::COLOR_ATTACHMENT0, gl::RENDERBUFFER, s);
             }
             NewTexture::Texture(t) => {
-                if is_embedded {
-                    gl.FramebufferTexture2D(target, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, t as _, level as _);
-                }
-                else {
-                    gl.FramebufferTexture(target, gl::COLOR_ATTACHMENT0, t as _, level as _);
-                }
+                state::set_framebuffer_texture(gl, target, gl::COLOR_ATTACHMENT0, t as _, level as _, is_embedded);
             }
         };
         gl.ReadBuffer(gl::COLOR_ATTACHMENT0);

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -752,7 +752,7 @@ fn tex_sub_image<F>(gl: &gl::Gl, kind: t::Kind, target: GLenum, pix: GLenum,
     })
 }
 
-fn bind_read_fbo(gl: &gl::Gl, texture: NewTexture, level: t::Level, fbo: FrameBuffer) {
+fn bind_read_fbo(gl: &gl::Gl, texture: NewTexture, level: t::Level, fbo: FrameBuffer, is_embedded: bool) {
     let target = gl::READ_FRAMEBUFFER;
     if texture == NewTexture::Surface(0) {
         //Warning: assuming the back buffer
@@ -773,7 +773,12 @@ fn bind_read_fbo(gl: &gl::Gl, texture: NewTexture, level: t::Level, fbo: FrameBu
                 gl.FramebufferRenderbuffer(target, gl::COLOR_ATTACHMENT0, gl::RENDERBUFFER, s);
             }
             NewTexture::Texture(t) => {
-                gl.FramebufferTexture(target, gl::COLOR_ATTACHMENT0, t as _, level as _);
+                if is_embedded {
+                    gl.FramebufferTexture2D(target, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, t as _, level as _);
+                }
+                else {
+                    gl.FramebufferTexture(target, gl::COLOR_ATTACHMENT0, t as _, level as _);
+                }
             }
         };
         gl.ReadBuffer(gl::COLOR_ATTACHMENT0);
@@ -808,6 +813,7 @@ pub fn copy_to_buffer(
     src: &t::TextureCopyRegion<NewTexture>,
     dst: Buffer, dst_offset: gl::types::GLintptr,
     fbo: FrameBuffer,
+    is_embedded: bool,
 ) -> Result<(), t::CreationError> {
     let data = dst_offset as *mut GLvoid;
     unsafe { gl.BindBuffer(gl::PIXEL_PACK_BUFFER, dst); }
@@ -846,7 +852,7 @@ pub fn copy_to_buffer(
         }
         _ => {
             assert!(src.info.depth <= 1);
-            bind_read_fbo(gl, src.texture, src.info.mipmap, fbo);
+            bind_read_fbo(gl, src.texture, src.info.mipmap, fbo, is_embedded);
             unsafe {
                 gl.ReadPixels(
                     src.info.xoffset as _,
@@ -865,8 +871,9 @@ pub fn copy_to_buffer(
 pub fn copy_textures(
     gl: &gl::Gl, src: &t::TextureCopyRegion<NewTexture>,
     dst: &t::TextureCopyRegion<Texture>, fbo: FrameBuffer,
+    is_embedded: bool,
 ) -> Result<(), t::CreationError> {
-    bind_read_fbo(gl, src.texture, src.info.mipmap, fbo);
+    bind_read_fbo(gl, src.texture, src.info.mipmap, fbo, is_embedded);
     let bind_target = kind_to_gl(dst.kind);
     unsafe { gl.BindTexture(bind_target, dst.texture); }
     let copy_target = match dst.cube_face {


### PR DESCRIPTION
GLES has glFramebufferTexture2D, but not glFramebufferTexture.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
