### PR TITLE
Make update_buffer use buffer's Role

### DIFF
--- a/src/backend/dx11/src/command.rs
+++ b/src/backend/dx11/src/command.rs
@@ -25,7 +25,7 @@ use winapi::um::d3d11::{
     ID3D11RasterizerState, ID3D11DepthStencilState, ID3D11BlendState,
 };
 
-use core::{command, pso, shade, state, target, texture as tex};
+use core::{command, buffer, pso, shade, state, target, texture as tex};
 use core::{IndexType, VertexCount};
 use core::{MAX_VERTEX_ATTRIBUTES, MAX_CONSTANT_BUFFERS,
            MAX_RESOURCE_VIEWS, MAX_UNORDERED_VIEWS,
@@ -348,7 +348,7 @@ impl<P: 'static + Parser> command::Buffer<Resources> for CommandBuffer<P> {
         self.parser.parse(Command::CopyTexture(src, dst));
     }
 
-    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize) {
+    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize, role: buffer::Role) {
         self.parser.update_buffer(buf, data, offset);
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -15,7 +15,7 @@
 #![allow(missing_docs)]
 
 use gl;
-use core::{self as c, command, state as s};
+use core::{self as c, command, state as s, buffer};
 use core::target::{ColorValue, Depth, Mirror, Rect, Stencil};
 use core::texture::TextureCopyRegion;
 use {Buffer, BufferElement, Program, FrameBuffer, Texture,
@@ -111,7 +111,7 @@ pub enum Command {
                          TextureCopyRegion<Texture>,
                          FrameBuffer),
     // resource updates
-    UpdateBuffer(Buffer, DataPointer, usize),
+    UpdateBuffer(Buffer, DataPointer, usize, buffer::Role),
     UpdateTexture(TextureCopyRegion<Texture>, DataPointer),
     GenerateMipmap(ResourceView),
     // drawing
@@ -587,9 +587,9 @@ impl command::Buffer<Resources> for CommandBuffer {
         }
     }
 
-    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset_bytes: usize) {
+    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset_bytes: usize, role: buffer::Role) {
         let ptr = self.data.add(data);
-        self.buf.push(Command::UpdateBuffer(buf, ptr, offset_bytes));
+        self.buf.push(Command::UpdateBuffer(buf, ptr, offset_bytes, role));
     }
 
     fn update_texture(&mut self,

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -26,7 +26,7 @@ use std::cell::RefCell;
 use std::error::Error as StdError;
 use std::fmt;
 use std::rc::Rc;
-use core::{self as c, handle, state as s, format, pso, texture, command as com, buffer};
+use core::{self as c, handle, state as s, format, pso, texture, command as com};
 use core::target::{Layer, Level};
 use command::{Command, DataBuffer};
 use factory::MappingKind;
@@ -654,10 +654,10 @@ impl Device {
                     Err(e) => error!("GL: {:?} failed: {:?}", cmd, e)
                 }
             },
-            Command::UpdateBuffer(buffer, pointer, offset) => {
+            Command::UpdateBuffer(buffer, pointer, offset, role) => {
                 let data = data_buf.get(pointer);
                 factory::update_sub_buffer(&self.share.context, buffer,
-                    data.as_ptr(), data.len(), offset, buffer::Role::Vertex);
+                    data.as_ptr(), data.len(), offset, role);
             },
             Command::UpdateTexture(ref dst, pointer) => {
                 let data = data_buf.get(pointer);

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -344,7 +344,7 @@ impl command::Buffer<Resources> for CommandBuffer {
         unimplemented!()
     }
 
-    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize) {
+    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize, _: buffer::Role) {
         use map::{map_buffer_usage};
 
         debug_assert!(!unsafe { *(*(buf.0).0) }.is_null(), "Buffer must be non-nil");

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -15,7 +15,7 @@
 use std::{mem, ptr};
 use std::collections::hash_map::{HashMap, Entry};
 use vk;
-use core::{self, pso, shade, target, texture as tex, handle};
+use core::{self, pso, shade, target, texture as tex, handle, buffer};
 use core::command::{self, AccessInfo, AccessGuard};
 use core::state::RefValues;
 use core::{IndexType, VertexCount, SubmissionResult};
@@ -262,7 +262,7 @@ impl command::Buffer<Resources> for Buffer {
         unimplemented!()
     }
 
-    fn update_buffer(&mut self, _: native::Buffer, _: &[u8], _: usize) {}
+    fn update_buffer(&mut self, _: native::Buffer, _: &[u8], _: usize, _: buffer::Role) {}
     fn update_texture(&mut self, _: tex::TextureCopyRegion<native::Texture>, _: &[u8]) {}
     fn generate_mipmap(&mut self, _: native::TextureView) {}
 

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -18,7 +18,7 @@ use std::ops::Deref;
 use std::collections::hash_set::{self, HashSet};
 use {Resources, IndexType, InstanceCount, VertexCount,
      SubmissionResult, SubmissionError};
-use {state, target, pso, shade, texture, handle};
+use {state, target, pso, shade, texture, handle, buffer};
 
 /// A universal clear color supporting integet formats
 /// as well as the standard floating-point.
@@ -82,7 +82,7 @@ pub trait Buffer<R: Resources>: 'static + Send {
                                src: texture::TextureCopyRegion<R::Texture>,
                                dst: texture::TextureCopyRegion<R::Texture>);
     /// Update a vertex/index/uniform buffer
-    fn update_buffer(&mut self, R::Buffer, data: &[u8], offset: usize);
+    fn update_buffer(&mut self, R::Buffer, data: &[u8], offset: usize, role: buffer::Role);
     /// Update a texture
     fn update_texture(&mut self, texture::TextureCopyRegion<R::Texture>, data: &[u8]);
     fn generate_mipmap(&mut self, R::ShaderResourceView);

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -16,7 +16,7 @@
 //! outside of the graphics development environment.
 
 use {Capabilities, Device, SubmissionResult, Resources, IndexType, VertexCount};
-use {state, target, handle, mapping, pso, shade, texture};
+use {state, target, handle, mapping, pso, shade, texture, buffer};
 use command::{self, AccessInfo};
 
 /// Dummy device which does minimal work, just to allow testing
@@ -105,7 +105,7 @@ impl command::Buffer<DummyResources> for DummyCommandBuffer {
     fn copy_texture_to_texture(&mut self,
                                _: texture::TextureCopyRegion<()>,
                                _: texture::TextureCopyRegion<()>) {}
-    fn update_buffer(&mut self, _: (), _: &[u8], _: usize) {}
+    fn update_buffer(&mut self, _: (), _: &[u8], _: usize, _: buffer::Role) {}
     fn update_texture(&mut self, _: texture::TextureCopyRegion<()>, _: &[u8]) {}
     fn generate_mipmap(&mut self, _: ()) {}
     fn clear_color(&mut self, _: (), _: command::ClearColor) {}

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -420,7 +420,7 @@ impl<R: Resources, C: command::Buffer<R>> Encoder<R, C> {
         if bound <= buf.get_info().size {
             self.command_buffer.update_buffer(
                 self.handles.ref_buffer(buf.raw()).clone(),
-                cast_slice(data), offset_bytes);
+                cast_slice(data), offset_bytes, buf.get_info().role);
             Ok(())
         } else {
             Err(UpdateError::OutOfBounds {
@@ -440,7 +440,7 @@ impl<R: Resources, C: command::Buffer<R>> Encoder<R, C> {
             slice::from_raw_parts(data as *const T as *const u8, mem::size_of::<T>())
         };
         self.command_buffer.update_buffer(
-            self.handles.ref_buffer(buf.raw()).clone(), slice, 0);
+            self.handles.ref_buffer(buf.raw()).clone(), slice, 0, buf.get_info().role);
     }
 
     /// Update the contents of a texture.


### PR DESCRIPTION
Previously, GL always bound the buffer as a vertex buffer when updating its content. This caused errors when updating index buffers.

Verified that the fix works on WebGL and DirectX